### PR TITLE
Add arithmetic symbols

### DIFF
--- a/_examples/main.or
+++ b/_examples/main.or
@@ -20,10 +20,10 @@ Println(1.1) ; say 1.1
 
 ;; Extreme decimal precision ( 0.1 + 0.2 is 0.3! )
 
-Println("0.1 + 0.2 =", Sum(0.1, 0.2))        ; say 0.1 + 0.2 ( 0.3 )
-Println("0.1 - 0.2 =", Difference(0.1, 0.2)) ; say 0.1 - 0.2 ( -0.1 )
-Println("0.1 * 3.0 =", Product(0.1, 3.0))    ; say 0.1 * 3.0 ( 0.3 )
-Println("0.1 / 3.0 =", Quotient(0.1, 3.0))   ; say 0.1 / 3.0 ( 0.0333333333333333...)
+Println("0.1 + 0.2 =", 0.1 + 0.2)        ; say 0.1 + 0.2 ( 0.3 )
+Println("0.1 - 0.2 =", 0.1 - 0.2) ; say 0.1 - 0.2 ( -0.1 )
+Println("0.1 * 3.0 =", 0.1 * 3.0)    ; say 0.1 * 3.0 ( 0.3 )
+Println("0.1 / 3.0 =", 0.1 / 3.0)   ; say 0.1 / 3.0 ( 0.0333333333333333...)
 Println("0.567854 rounded to nearest whole number =", Round(0.567854)) ; 1
 Println("2.05 rounded to upper whole number =", Ceil(2.05)) ; 3
 Println("2.05 rounded to lower whole number =", Floor(2.05)) ; 2

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -286,20 +286,21 @@ var accept = []token.Type{
 	token.Error, 
 	token.T_0, 
 	token.T_1, 
+	token.T_9, 
 	token.T_2, 
-	token.Error, 
+	token.T_9, 
 	token.T_8, 
 	token.T_6, 
 	token.T_6, 
-	token.T_6, 
 	token.T_4, 
+	token.T_6, 
 	token.Error, 
 	token.Error, 
 	token.Error, 
 	token.T_6, 
 	token.T_6, 
 	token.Error, 
-	token.T_10, 
+	token.T_11, 
 	token.Error, 
 	token.T_5, 
 	token.T_6, 
@@ -308,7 +309,7 @@ var accept = []token.Type{
 	token.T_6, 
 	token.T_6, 
 	token.T_6, 
-	token.T_9, 
+	token.T_10, 
 }
 
 var nextState = []func(r rune) state{ 
@@ -321,20 +322,26 @@ var nextState = []func(r rune) state{
 			return 2 
 		case r == ')':
 			return 3 
+		case r == '*':
+			return 4 
+		case r == '+':
+			return 4 
 		case r == ',':
+			return 5 
+		case r == '-':
 			return 4 
 		case r == '/':
-			return 5 
-		case r == ';':
 			return 6 
-		case r == 'g':
+		case r == ';':
 			return 7 
-		case r == 'p':
+		case r == 'g':
 			return 8 
-		case unicode.IsLetter(r):
+		case r == 'p':
 			return 9 
 		case unicode.IsNumber(r):
 			return 10 
+		case unicode.IsLetter(r):
+			return 11 
 		}
 		return nullState
 	}, 
@@ -342,9 +349,9 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '\\':
-			return 11 
-		case not(r, []rune{'"','\\'}):
 			return 12 
+		case not(r, []rune{'"','\\'}):
+			return 13 
 		}
 		return nullState
 	}, 
@@ -369,34 +376,22 @@ var nextState = []func(r rune) state{
 	// Set5
 	func(r rune) state {
 		switch { 
-		case r == '*':
-			return 13 
 		}
 		return nullState
 	}, 
 	// Set6
 	func(r rune) state {
 		switch { 
-		case not(r, []rune{'\n'}):
-			return 6 
+		case r == '*':
+			return 14 
 		}
 		return nullState
 	}, 
 	// Set7
 	func(r rune) state {
 		switch { 
-		case r == '/':
-			return 9 
-		case r == '?':
-			return 9 
-		case r == '_':
-			return 9 
-		case r == 'e':
-			return 14 
-		case unicode.IsLetter(r):
-			return 9 
-		case unicode.IsNumber(r):
-			return 9 
+		case not(r, []rune{'\n'}):
+			return 7 
 		}
 		return nullState
 	}, 
@@ -404,17 +399,17 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
+			return 11 
 		case r == '?':
-			return 9 
+			return 11 
 		case r == '_':
-			return 9 
-		case r == 'a':
+			return 11 
+		case r == 'e':
 			return 15 
 		case unicode.IsLetter(r):
-			return 9 
+			return 11 
 		case unicode.IsNumber(r):
-			return 9 
+			return 11 
 		}
 		return nullState
 	}, 
@@ -422,15 +417,17 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
+			return 11 
 		case r == '?':
-			return 9 
+			return 11 
 		case r == '_':
-			return 9 
+			return 11 
+		case r == 'a':
+			return 16 
 		case unicode.IsLetter(r):
-			return 9 
+			return 11 
 		case unicode.IsNumber(r):
-			return 9 
+			return 11 
 		}
 		return nullState
 	}, 
@@ -438,7 +435,7 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '.':
-			return 16 
+			return 17 
 		case unicode.IsNumber(r):
 			return 10 
 		}
@@ -447,29 +444,35 @@ var nextState = []func(r rune) state{
 	// Set11
 	func(r rune) state {
 		switch { 
-		case any(r, []rune{'"','\\','n','r','t'}):
-			return 12 
+		case r == '/':
+			return 11 
+		case r == '?':
+			return 11 
+		case r == '_':
+			return 11 
+		case unicode.IsLetter(r):
+			return 11 
+		case unicode.IsNumber(r):
+			return 11 
 		}
 		return nullState
 	}, 
 	// Set12
 	func(r rune) state {
 		switch { 
-		case r == '"':
-			return 17 
-		case r == '\\':
-			return 11 
-		case not(r, []rune{'"','\\'}):
-			return 12 
+		case any(r, []rune{'"','\\','n','r','t'}):
+			return 13 
 		}
 		return nullState
 	}, 
 	// Set13
 	func(r rune) state {
 		switch { 
-		case r == '*':
+		case r == '"':
 			return 18 
-		case not(r, []rune{'*'}):
+		case r == '\\':
+			return 12 
+		case not(r, []rune{'"','\\'}):
 			return 13 
 		}
 		return nullState
@@ -477,18 +480,10 @@ var nextState = []func(r rune) state{
 	// Set14
 	func(r rune) state {
 		switch { 
-		case r == '/':
-			return 9 
-		case r == '?':
-			return 9 
-		case r == '_':
-			return 9 
-		case r == 't':
+		case r == '*':
 			return 19 
-		case unicode.IsLetter(r):
-			return 9 
-		case unicode.IsNumber(r):
-			return 9 
+		case not(r, []rune{'*'}):
+			return 14 
 		}
 		return nullState
 	}, 
@@ -496,41 +491,49 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
+			return 11 
 		case r == '?':
-			return 9 
+			return 11 
 		case r == '_':
-			return 9 
-		case r == 'c':
+			return 11 
+		case r == 't':
 			return 20 
 		case unicode.IsLetter(r):
-			return 9 
+			return 11 
 		case unicode.IsNumber(r):
-			return 9 
+			return 11 
 		}
 		return nullState
 	}, 
 	// Set16
 	func(r rune) state {
 		switch { 
-		case unicode.IsNumber(r):
+		case r == '/':
+			return 11 
+		case r == '?':
+			return 11 
+		case r == '_':
+			return 11 
+		case r == 'c':
 			return 21 
+		case unicode.IsLetter(r):
+			return 11 
+		case unicode.IsNumber(r):
+			return 11 
 		}
 		return nullState
 	}, 
 	// Set17
 	func(r rune) state {
 		switch { 
+		case unicode.IsNumber(r):
+			return 22 
 		}
 		return nullState
 	}, 
 	// Set18
 	func(r rune) state {
 		switch { 
-		case r == '/':
-			return 22 
-		case not(r, []rune{'/'}):
-			return 13 
 		}
 		return nullState
 	}, 
@@ -538,15 +541,9 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
-		case r == '?':
-			return 9 
-		case r == '_':
-			return 9 
-		case unicode.IsLetter(r):
-			return 9 
-		case unicode.IsNumber(r):
-			return 9 
+			return 23 
+		case not(r, []rune{'/'}):
+			return 14 
 		}
 		return nullState
 	}, 
@@ -554,49 +551,47 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
+			return 11 
 		case r == '?':
-			return 9 
+			return 11 
 		case r == '_':
-			return 9 
-		case r == 'k':
-			return 23 
+			return 11 
 		case unicode.IsLetter(r):
-			return 9 
+			return 11 
 		case unicode.IsNumber(r):
-			return 9 
+			return 11 
 		}
 		return nullState
 	}, 
 	// Set21
 	func(r rune) state {
 		switch { 
+		case r == '/':
+			return 11 
+		case r == '?':
+			return 11 
+		case r == '_':
+			return 11 
+		case r == 'k':
+			return 24 
+		case unicode.IsLetter(r):
+			return 11 
 		case unicode.IsNumber(r):
-			return 21 
+			return 11 
 		}
 		return nullState
 	}, 
 	// Set22
 	func(r rune) state {
 		switch { 
+		case unicode.IsNumber(r):
+			return 22 
 		}
 		return nullState
 	}, 
 	// Set23
 	func(r rune) state {
 		switch { 
-		case r == '/':
-			return 9 
-		case r == '?':
-			return 9 
-		case r == '_':
-			return 9 
-		case r == 'a':
-			return 24 
-		case unicode.IsLetter(r):
-			return 9 
-		case unicode.IsNumber(r):
-			return 9 
 		}
 		return nullState
 	}, 
@@ -604,17 +599,17 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
+			return 11 
 		case r == '?':
-			return 9 
+			return 11 
 		case r == '_':
-			return 9 
-		case r == 'g':
+			return 11 
+		case r == 'a':
 			return 25 
 		case unicode.IsLetter(r):
-			return 9 
+			return 11 
 		case unicode.IsNumber(r):
-			return 9 
+			return 11 
 		}
 		return nullState
 	}, 
@@ -622,17 +617,17 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
+			return 11 
 		case r == '?':
-			return 9 
+			return 11 
 		case r == '_':
-			return 9 
-		case r == 'e':
+			return 11 
+		case r == 'g':
 			return 26 
 		case unicode.IsLetter(r):
-			return 9 
+			return 11 
 		case unicode.IsNumber(r):
-			return 9 
+			return 11 
 		}
 		return nullState
 	}, 
@@ -640,15 +635,33 @@ var nextState = []func(r rune) state{
 	func(r rune) state {
 		switch { 
 		case r == '/':
-			return 9 
+			return 11 
 		case r == '?':
-			return 9 
+			return 11 
 		case r == '_':
-			return 9 
+			return 11 
+		case r == 'e':
+			return 27 
 		case unicode.IsLetter(r):
-			return 9 
+			return 11 
 		case unicode.IsNumber(r):
-			return 9 
+			return 11 
+		}
+		return nullState
+	}, 
+	// Set27
+	func(r rune) state {
+		switch { 
+		case r == '/':
+			return 11 
+		case r == '?':
+			return 11 
+		case r == '_':
+			return 11 
+		case unicode.IsLetter(r):
+			return 11 
+		case unicode.IsNumber(r):
+			return 11 
 		}
 		return nullState
 	}, 

--- a/orion.md
+++ b/orion.md
@@ -46,6 +46,11 @@ integer : number {number} ;
 float : integer ['.' integer] ;
 ```
 
+### Operation Symbols:
+```
+op : ('+' | '-' | '*' | '/') ;
+```
+
 ## The Orion Rule
 
 It is the root rule for all statements in Orion.
@@ -130,9 +135,10 @@ DataList
 ## The Data Rule
 
 It represents all data types in Orion: string, numbers, etc.
+It also represents variables (_TODO_) and operations.
 
 ```
-Data : String | FuncCall | Number ;
+Data : String | FuncCall | Number | Operation ;
 ```
 
 ### The String Rule
@@ -149,4 +155,15 @@ It represents all integers and floating-point numbers in Orion.
 
 ```
 Number : integer | float ;
+```
+
+### The Operation Rule
+
+It represents all the operations in Orion.
+
+```
+Operation 
+        : Number
+        | Operation op Number
+        ;
 ```

--- a/parser/slot/slot.go
+++ b/parser/slot/slot.go
@@ -18,6 +18,8 @@ const(
 	Data1R1
 	Data2R0
 	Data2R1
+	Data3R0
+	Data3R1
 	DataList0R0
 	DataList0R1
 	DataList1R0
@@ -36,6 +38,12 @@ const(
 	Number0R1
 	Number1R0
 	Number1R1
+	Operation0R0
+	Operation0R1
+	Operation1R0
+	Operation1R1
+	Operation1R2
+	Operation1R3
 	Orion0R0
 	Orion0R1
 	Orion0R2
@@ -183,6 +191,20 @@ var slots = map[Label]*Slot{
 			symbols.NT_Number,
 		}, 
 		Data2R1, 
+	},
+	Data3R0: {
+		symbols.NT_Data, 3, 0, 
+		symbols.Symbols{  
+			symbols.NT_Operation,
+		}, 
+		Data3R0, 
+	},
+	Data3R1: {
+		symbols.NT_Data, 3, 1, 
+		symbols.Symbols{  
+			symbols.NT_Operation,
+		}, 
+		Data3R1, 
 	},
 	DataList0R0: {
 		symbols.NT_DataList, 0, 0, 
@@ -336,6 +358,56 @@ var slots = map[Label]*Slot{
 		}, 
 		Number1R1, 
 	},
+	Operation0R0: {
+		symbols.NT_Operation, 0, 0, 
+		symbols.Symbols{  
+			symbols.NT_Number,
+		}, 
+		Operation0R0, 
+	},
+	Operation0R1: {
+		symbols.NT_Operation, 0, 1, 
+		symbols.Symbols{  
+			symbols.NT_Number,
+		}, 
+		Operation0R1, 
+	},
+	Operation1R0: {
+		symbols.NT_Operation, 1, 0, 
+		symbols.Symbols{  
+			symbols.NT_Operation, 
+			symbols.T_9, 
+			symbols.NT_Number,
+		}, 
+		Operation1R0, 
+	},
+	Operation1R1: {
+		symbols.NT_Operation, 1, 1, 
+		symbols.Symbols{  
+			symbols.NT_Operation, 
+			symbols.T_9, 
+			symbols.NT_Number,
+		}, 
+		Operation1R1, 
+	},
+	Operation1R2: {
+		symbols.NT_Operation, 1, 2, 
+		symbols.Symbols{  
+			symbols.NT_Operation, 
+			symbols.T_9, 
+			symbols.NT_Number,
+		}, 
+		Operation1R2, 
+	},
+	Operation1R3: {
+		symbols.NT_Operation, 1, 3, 
+		symbols.Symbols{  
+			symbols.NT_Operation, 
+			symbols.T_9, 
+			symbols.NT_Number,
+		}, 
+		Operation1R3, 
+	},
 	Orion0R0: {
 		symbols.NT_Orion, 0, 0, 
 		symbols.Symbols{  
@@ -363,24 +435,24 @@ var slots = map[Label]*Slot{
 	Package0R0: {
 		symbols.NT_Package, 0, 0, 
 		symbols.Symbols{  
-			symbols.T_9, 
-			symbols.T_10,
+			symbols.T_10, 
+			symbols.T_11,
 		}, 
 		Package0R0, 
 	},
 	Package0R1: {
 		symbols.NT_Package, 0, 1, 
 		symbols.Symbols{  
-			symbols.T_9, 
-			symbols.T_10,
+			symbols.T_10, 
+			symbols.T_11,
 		}, 
 		Package0R1, 
 	},
 	Package0R2: {
 		symbols.NT_Package, 0, 2, 
 		symbols.Symbols{  
-			symbols.T_9, 
-			symbols.T_10,
+			symbols.T_10, 
+			symbols.T_11,
 		}, 
 		Package0R2, 
 	},
@@ -453,14 +525,14 @@ var slots = map[Label]*Slot{
 	String0R0: {
 		symbols.NT_String, 0, 0, 
 		symbols.Symbols{  
-			symbols.T_10,
+			symbols.T_11,
 		}, 
 		String0R0, 
 	},
 	String0R1: {
 		symbols.NT_String, 0, 1, 
 		symbols.Symbols{  
-			symbols.T_10,
+			symbols.T_11,
 		}, 
 		String0R1, 
 	},
@@ -473,6 +545,8 @@ var slotIndex = map[Index]Label {
 	Index{ symbols.NT_Data,1,1 }: Data1R1,
 	Index{ symbols.NT_Data,2,0 }: Data2R0,
 	Index{ symbols.NT_Data,2,1 }: Data2R1,
+	Index{ symbols.NT_Data,3,0 }: Data3R0,
+	Index{ symbols.NT_Data,3,1 }: Data3R1,
 	Index{ symbols.NT_DataList,0,0 }: DataList0R0,
 	Index{ symbols.NT_DataList,0,1 }: DataList0R1,
 	Index{ symbols.NT_DataList,1,0 }: DataList1R0,
@@ -491,6 +565,12 @@ var slotIndex = map[Index]Label {
 	Index{ symbols.NT_Number,0,1 }: Number0R1,
 	Index{ symbols.NT_Number,1,0 }: Number1R0,
 	Index{ symbols.NT_Number,1,1 }: Number1R1,
+	Index{ symbols.NT_Operation,0,0 }: Operation0R0,
+	Index{ symbols.NT_Operation,0,1 }: Operation0R1,
+	Index{ symbols.NT_Operation,1,0 }: Operation1R0,
+	Index{ symbols.NT_Operation,1,1 }: Operation1R1,
+	Index{ symbols.NT_Operation,1,2 }: Operation1R2,
+	Index{ symbols.NT_Operation,1,3 }: Operation1R3,
 	Index{ symbols.NT_Orion,0,0 }: Orion0R0,
 	Index{ symbols.NT_Orion,0,1 }: Orion0R1,
 	Index{ symbols.NT_Orion,0,2 }: Orion0R2,
@@ -518,8 +598,9 @@ var alternates = map[symbols.NT][]Label{
 	symbols.NT_FuncCall:[]Label{ FuncCall0R0 },
 	symbols.NT_Import:[]Label{ Import0R0 },
 	symbols.NT_DataList:[]Label{ DataList0R0,DataList1R0 },
-	symbols.NT_Data:[]Label{ Data0R0,Data1R0,Data2R0 },
+	symbols.NT_Data:[]Label{ Data0R0,Data1R0,Data2R0,Data3R0 },
 	symbols.NT_String:[]Label{ String0R0 },
 	symbols.NT_Number:[]Label{ Number0R0,Number1R0 },
+	symbols.NT_Operation:[]Label{ Operation0R0,Operation1R0 },
 }
 

--- a/parser/symbols/symbols.go
+++ b/parser/symbols/symbols.go
@@ -24,6 +24,7 @@ const(
 	NT_FuncCall 
 	NT_Import 
 	NT_Number 
+	NT_Operation 
 	NT_Orion 
 	NT_Package 
 	NT_Statement 
@@ -43,8 +44,9 @@ const(
 	T_6  // ident 
 	T_7  // integer 
 	T_8  // line_comment 
-	T_9  // package 
-	T_10  // string_lit 
+	T_9  // op 
+	T_10  // package 
+	T_11  // string_lit 
 )
 
 type Symbols []Symbol
@@ -117,6 +119,7 @@ var ntToString = []string {
 	"FuncCall", /* NT_FuncCall */
 	"Import", /* NT_Import */
 	"Number", /* NT_Number */
+	"Operation", /* NT_Operation */
 	"Orion", /* NT_Orion */
 	"Package", /* NT_Package */
 	"Statement", /* NT_Statement */
@@ -134,8 +137,9 @@ var tToString = []string {
 	"ident", /* T_6 */
 	"integer", /* T_7 */
 	"line_comment", /* T_8 */
-	"package", /* T_9 */
-	"string_lit", /* T_10 */ 
+	"op", /* T_9 */
+	"package", /* T_10 */
+	"string_lit", /* T_11 */ 
 }
 
 var stringNT = map[string]NT{ 
@@ -144,6 +148,7 @@ var stringNT = map[string]NT{
 	"FuncCall":NT_FuncCall,
 	"Import":NT_Import,
 	"Number":NT_Number,
+	"Operation":NT_Operation,
 	"Orion":NT_Orion,
 	"Package":NT_Package,
 	"Statement":NT_Statement,

--- a/token/token.go
+++ b/token/token.go
@@ -144,8 +144,9 @@ const(
     T_6  // ident 
     T_7  // integer 
     T_8  // line_comment 
-    T_9  // package 
-    T_10  // string_lit 
+    T_9  // op 
+    T_10  // package 
+    T_11  // string_lit 
 )
 
 var TypeToString = []string{ 
@@ -162,6 +163,7 @@ var TypeToString = []string{
     "T_8",
     "T_9",
     "T_10",
+    "T_11",
 }
 
 var StringToType = map[string] Type { 
@@ -178,6 +180,7 @@ var StringToType = map[string] Type {
     "T_8" : T_8, 
     "T_9" : T_9, 
     "T_10" : T_10, 
+    "T_11" : T_11, 
 }
 
 var TypeToID = []string { 
@@ -192,6 +195,7 @@ var TypeToID = []string {
     "ident", 
     "integer", 
     "line_comment", 
+    "op", 
     "package", 
     "string_lit", 
 }
@@ -208,8 +212,9 @@ var IDToType = map[string]Type {
     "ident": 8, 
     "integer": 9, 
     "line_comment": 10, 
-    "package": 11, 
-    "string_lit": 12, 
+    "op": 11, 
+    "package": 12, 
+    "string_lit": 13, 
 }
 
 var Suppress = []bool { 
@@ -224,6 +229,7 @@ var Suppress = []bool {
     false, 
     false, 
     true, 
+    false, 
     false, 
     false, 
 }


### PR DESCRIPTION
## What?

I have added arithmetic symbols to Orion. Now, instead of using functions to operate on numbers, we can also just use `+`, `-`, `*`, `/` for the operations.

## Why?

These changes gives the user a smoother experience with Orion.

## How?

I modified `orion.md` by adding the `op` and `Operation` rules. Then, I modified `parse.go` to include this new rule. The parsed rule just returns a function node for the corresponding arithmetic function.

## Testing?

All the previous tests have passed and no other additional tests have been added.

## Screenshots
<details>
<summary>The main example (top) and result (bottom). NOTE: The full result is not given, only the relevant bit.</summary>
<img width="1470" alt="Screenshot 2024-11-17 at 11 39 08 AM" src="https://github.com/user-attachments/assets/3a4546a9-0638-45ff-a2fe-f2d59c23bf5f" />
</details>

## Anything Else?
I have also restructured the parsing mechanism a bit. The diff should clarify that.